### PR TITLE
Fetch with SSR 100 photos of dogs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,17 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  images: {
+    formats: ["image/avif", "image/webp"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "live.staticflickr.com",
+        port: "",
+        pathname: "/**/**",
+      },
+    ],
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/src/lib/Flickr.ts
+++ b/src/lib/Flickr.ts
@@ -1,0 +1,6 @@
+export const getDogsPhotos = async () => {
+  const res = await fetch("https://api.flickr.com/services/rest/?method=flickr.photos.search&api_key=06fe421ea76dcc08939e8e4202b4d933&text=dogs&format=json&nojsoncallback=1", {
+    method: "GET",
+  }).then(res => res.json()).then(res => res.photos).then(res => res.photo).catch(error => new Error(error))
+  return res;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,19 @@
+import { InferGetServerSidePropsType } from 'next'
+import Image from 'next/image'
 import Head from 'next/head'
+import { getDogsPhotos } from '~/lib/Flickr'
+import { Photo } from '~/types'
 
-export default function Home() {
+export const getServerSideProps = async () => {
+  const photos = await getDogsPhotos()
+  return {
+    props: {
+      photos
+    },
+  }
+}
+
+export default function Home({ photos }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <>
       <Head>
@@ -11,9 +24,16 @@ export default function Home() {
       </Head>
       <main>
         <h1>Flickr&apos;s Photos Gallery</h1>
+        {photos?.map((photo: Photo, index: number) => (
+          <Image
+            key={index}
+            src={`https://live.staticflickr.com/${photo.server}/${photo.id}_${photo.secret}.jpg`}
+            width={500}
+            height={500}
+            alt={photo.title}
+          />
+        ))}
       </main>
     </>
   )
 }
-
-// https://api.flickr.com/services/rest/?method=flickr.photos.search&api_key=06fe421ea76dcc08939e8e4202b4d933&text=dogs&format=json&nojsoncallback=1

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,11 @@
+export interface Photo {
+  id: string,
+  owner: string,
+  secret: string,
+  server: string,
+  farm: number,
+  title: string,
+  ispublic: boolean,
+  isfriend: boolean,
+  isfamily: boolean
+}


### PR DESCRIPTION
Commit following changes:
 - create Photo interface in order to use proper type of data,
 - create Flickr.ts library for the communication with Flickr's API,
 - configure remotePattern in next.config.js in order to upload images form URL source
 - render first 100 photos of dogs on the Home Page using getServerSideProps

 - *enable AVIF formats in next.js in order to prevent Firefox 67+ from bugs in the future
(*this will be checked in the future in other
commits connected with browser bugs, so this
change is not relevant right now)