### PR TITLE
Fetch photos with useSWR hook

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,9 @@ const nextConfig = {
       },
     ],
   },
+  env: {
+    API_KEY: '06fe421ea76dcc08939e8e4202b4d933',
+  },
 };
 
 module.exports = nextConfig;

--- a/src/components/PhotosList.tsx
+++ b/src/components/PhotosList.tsx
@@ -1,0 +1,45 @@
+import usePhotos from "~/hooks/usePhotos"
+import { Photo } from "~/types"
+import Image from "next/image"
+import { useEffect } from "react"
+import Link from "next/link"
+
+interface Props {
+  index: number,
+}
+
+const PhotosList = ({ index }: Props) => {
+  const { data, isLoading, isValidating, error } = usePhotos(index)
+
+  const photos = isLoading ? null : data?.photo
+
+  useEffect(() => {
+    console.log(photos)
+  }, [photos])
+
+  return (
+    <>
+      {isValidating && <h1>Validating...</h1>}
+      {isLoading ? <h2>Loading...</h2>
+        : <div>
+          {photos?.map((photo: Photo) => (
+            <>
+              <h1>{photo.id}</h1>
+              <Image
+                key={photo.id}
+                src={`https://live.staticflickr.com/${photo.server}/${photo.id}_${photo.secret}.jpg`}
+                width={200}
+                height={200}
+                alt={photo.title}
+              />
+            </>
+          ))}
+          <h1 className='bg-slate-500 font-bold'>END of list no {index}.</h1>
+        </div>
+      }
+      {error && <h2>Error: {error.message}</h2>}
+    </>
+  )
+}
+
+export default PhotosList

--- a/src/hooks/usePhotos.ts
+++ b/src/hooks/usePhotos.ts
@@ -1,0 +1,24 @@
+import useSWR from "swr"
+import { fetcher } from "~/lib/swr"
+import { Response } from "~/types"
+
+export const usePhotos = (index: number) => {
+  const swr = useSWR<Response>(`https://api.flickr.com/services/rest/?method=flickr.photos.search&api_key=06fe421ea76dcc08939e8e4202b4d933&text=dogs&format=json&nojsoncallback=1&page=${index}&per_page=100`, fetcher, {
+    revalidateIfStale: false,
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+  })
+
+  swr.data?.photos?.photo.sort((a, b) => {
+    return a.id.localeCompare(b.id);
+  });
+
+  return {
+    data: swr.data?.photos,
+    isLoading: swr.isLoading,
+    isValidating: swr.isValidating,
+    error: swr.error
+  }
+}
+
+export default usePhotos

--- a/src/lib/swr.ts
+++ b/src/lib/swr.ts
@@ -1,0 +1,7 @@
+export const fetcher = async <T = Response>(url: string): Promise<T> => {
+  const res = await fetch(url, {
+    method: "GET",
+  })
+
+  return res.json()
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,19 +1,16 @@
-import { InferGetServerSidePropsType } from 'next'
-import Image from 'next/image'
 import Head from 'next/head'
-import { getDogsPhotos } from '~/lib/Flickr'
-import { Photo } from '~/types'
+import { useState } from 'react'
+import PhotosList from '~/components/PhotosList'
 
-export const getServerSideProps = async () => {
-  const photos = await getDogsPhotos()
-  return {
-    props: {
-      photos
-    },
+export default function Home() {
+  const [cnt, setCnt] = useState(1)
+
+  const pages = []
+
+  for (let i = 0; i < cnt; i++) {
+    pages.push(<PhotosList index={i + 1} key={i + 1} />)
   }
-}
 
-export default function Home({ photos }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <>
       <Head>
@@ -24,15 +21,8 @@ export default function Home({ photos }: InferGetServerSidePropsType<typeof getS
       </Head>
       <main>
         <h1>Flickr&apos;s Photos Gallery</h1>
-        {photos?.map((photo: Photo, index: number) => (
-          <Image
-            key={index}
-            src={`https://live.staticflickr.com/${photo.server}/${photo.id}_${photo.secret}.jpg`}
-            width={500}
-            height={500}
-            alt={photo.title}
-          />
-        ))}
+        {pages}
+        <button className='border rounded-lg p-3 bg-slate-500 hover:bg-slate-400' onClick={() => setCnt(cnt + 1)}>Load More</button>
       </main>
     </>
   )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,3 +9,18 @@ export interface Photo {
   isfriend: boolean,
   isfamily: boolean
 }
+
+export interface Response {
+  photos?: Photos
+  stat: string
+  code: number
+  message?: string
+}
+
+export interface Photos {
+  page: number
+  pages:number
+  perpage: number
+  photo: Photo[]
+  total: number
+}


### PR DESCRIPTION
Instead of using getServerSideProps the useSWR hook has been implemented in order to optimize fetching more than one page/list of 100 photos. The solution took few steps:
 - create PhotosList component in order to reuse part of code for each page of fetched list of photos
 - create usePhotos hook which is used as a fecthing tool in PhotosList component. 'usePhotos' hook required creating:
        * swr.ts library with fetcher to export
        * Response and Photos interfaces
        * global API_KEY variable in next.config.js
 - implement in Home Page the infinite loading UI following the SWR docs using array of PhotosList components
(https://swr.vercel.app/docs/pagination#infinite-loading)