### PR TITLE
Divide PhotosList into two rows

### DIFF
--- a/src/components/PhotosList/PhotosList.tsx
+++ b/src/components/PhotosList/PhotosList.tsx
@@ -9,12 +9,16 @@ const PhotosList = ({ index }: Props) => {
   const { data, isLoading, isValidating, error } = usePhotos(index)
 
   const photos = isLoading ? null : data?.photo
+  const oddRow = photos?.slice(0, 50)
+  const evenRow = photos?.slice(50, 100)
 
   return (
     <>
-      {isValidating && <h1>Validating...</h1>}
       {
-        isLoading ? <h2>Loading...</h2> : photos && <PhotosRow photos={photos} />
+        isLoading || isValidating ? <h2>Loading...</h2> : oddRow && evenRow && <>
+          <PhotosRow photos={oddRow} odd />
+          <PhotosRow photos={evenRow} />
+        </>
       }
       {error && <h2>Error: {error.message}</h2>}
     </>

--- a/src/components/PhotosRow/PhotosRow.module.css
+++ b/src/components/PhotosRow/PhotosRow.module.css
@@ -3,18 +3,19 @@
 }
 
 .row {
-  @apply flex gap-3 overflow-x-auto pb-3 scrollbar-hide;
+  @apply flex gap-4 overflow-x-auto pb-4 scrollbar-hide;
 }
 
 .imageParent {
-  @apply relative min-h-[200px] min-w-[200px] flex-grow;
+  @apply relative min-h-[180px] min-w-[180px] flex-grow;
 }
+
 .image {
   @apply object-cover shadow-sm shadow-black transition;
 }
 
 .slideButton {
-  @apply absolute z-10 h-[200px] w-fit p-2 text-transparent transition hover:text-black hover:backdrop-blur-md;
+  @apply absolute z-10 h-[180px] w-[90px] p-2 text-transparent transition hover:text-black hover:backdrop-blur-md;
 }
 
 .slideRight {

--- a/src/components/PhotosRow/PhotosRow.tsx
+++ b/src/components/PhotosRow/PhotosRow.tsx
@@ -6,9 +6,10 @@ import styles from "./PhotosRow.module.css"
 
 interface Props {
   photos: Photo[],
+  odd?: boolean
 }
 
-const PhotosRow = ({ photos }: Props) => {
+const PhotosRow = ({ photos, odd }: Props) => {
   const [scrollLeft, setScrollLeft] = useState<number>(0)
   const [maxLeft, setMaxLeft] = useState<number>(10588)
   const rowRef = useRef<HTMLDivElement>(null)
@@ -16,9 +17,13 @@ const PhotosRow = ({ photos }: Props) => {
   useEffect(() => {
     const handleResize = () => {
       rowRef.current && setMaxLeft(rowRef.current.scrollWidth - rowRef.current.clientWidth)
+      console.log("resize")
     }
     window.addEventListener('resize', handleResize)
-  })
+    odd && rowRef.current?.scrollTo({
+      left: 90,
+    })
+  }, [])
 
   const slideLeft = () => {
     rowRef.current?.scrollTo({


### PR DESCRIPTION
The photos component is divided into odd
and even row in order to:
 (1) display 100 photos inside two rows
 (2) set offset (scrollLeft) for odd row
due to requirements of the design